### PR TITLE
icons showing up as wrong size in upgrade planner

### DIFF
--- a/prototypes/entity/gun-turret.lua
+++ b/prototypes/entity/gun-turret.lua
@@ -6,8 +6,8 @@ local turret2 = table.deepcopy(data.raw["ammo-turret"]["gun-turret"])
 turret2.name = "gun-turret-mk2"
 turret2.minable.result = turret2.name
 turret2.icon = "__FactorioExtended-Plus-Weaponry__/graphics/icons/gun-turret-mk2.png"
-turret2.icon_size = 32
-turret2.icon_mipmaps = nil
+turret2.icon_size = 64
+turret2.icon_mipmaps = 4
 
 turret2.max_health = 800 -- 400
 turret2.attacking_speed = 1 -- 0.5

--- a/prototypes/entity/laser-turret.lua
+++ b/prototypes/entity/laser-turret.lua
@@ -6,8 +6,8 @@ local turret2 = table.deepcopy(data.raw["electric-turret"]["laser-turret"])
 turret2.name = "laser-turret-mk2"
 turret2.minable.result = turret2.name
 turret2.icon = "__FactorioExtended-Plus-Weaponry__/graphics/icons/laser-turret-mk2.png"
-turret2.icon_size = 32
-turret2.icon_mipmaps = nil
+turret2.icon_size = 64
+turret2.icon_mipmaps = 4
 
 turret2.max_health = 2000 -- 1000
 turret2.energy_source.buffer_capacity = "1600kJ" -- 801kJ

--- a/prototypes/item/item-weapons.lua
+++ b/prototypes/item/item-weapons.lua
@@ -1,25 +1,5 @@
 data:extend(
     {
-        -- {
-        --     type = "item",
-        --     name = "gun-turret-mk2",
-        --     icon = "__FactorioExtended-Plus-Weaponry__/graphics/icons/gun-turret-mk2.png",
-        --     icon_size = 32,
-        --     subgroup = "fb-weapons",
-        --     order = "b-a",
-        --     place_result = "gun-turret-mk2",
-        --     stack_size = 50
-        -- },
-        -- {
-        --     type = "item",
-        --     name = "laser-turret-mk2",
-        --     icon = "__FactorioExtended-Plus-Weaponry__/graphics/icons/laser-turret-mk2.png",
-        --     icon_size = 32,
-        --     subgroup = "fb-weapons",
-        --     order = "b-b",
-        --     place_result = "laser-turret-mk2",
-        --     stack_size = 50
-        -- },
         {
             type = "ammo",
             name = "shattering-bullet-magazine",


### PR DESCRIPTION
When using an upgrade planner,  the entity icons are used.  These have been changed to use the same 64x64 icons that the items use.